### PR TITLE
feat: migrate Docker image builds from GHCR to ECR

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -1,53 +1,51 @@
-name: Build and push a Docker image
+name: Create and publish a Docker image
 
 on:
   push:
-    tags:
-    - '**'
     branches:
-    - '**'
-  workflow_dispatch:
+      - '**'
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-alpha.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"
 
 env:
-  REGISTRY: ghcr.io
+  REGISTRY: 187393211016.dkr.ecr.us-east-1.amazonaws.com
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
     permissions:
+      id-token: write
       contents: read
-      packages: write
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@v1
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          role-to-assume: arn:aws:iam::187393211016:role/GitHubActions-ECR-Push-Role-Ondo-GM
+          aws-region: us-east-1
+
+      - name: Log in to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            # set latest tag for default branch
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=schedule
-            type=ref,event=branch
-            type=ref,event=tag
-            type=ref,event=pr
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5.1.0


### PR DESCRIPTION
## Description
This PR is for migrating Infra toolkit docker image from GHCR to ECR

## Ref:
https://github.com/ondoprotocol/ondo-infra/issues/307

## Changes
- Migrated Docker image publishing from GitHub Container Registry (GHCR) to Amazon Elastic Container Registry (ECR)
- Updated authentication mechanism from GitHub tokens to AWS IAM role assumption
- Configured ECR registry endpoint: `187393211016.dkr.ecr.us-east-1.amazonaws.com`